### PR TITLE
fix connectionDetails logic so that the shared secret can be derived from the address

### DIFF
--- a/src/main/java/org/interledger/spsp/server/config/ilp/StreamConfig.java
+++ b/src/main/java/org/interledger/spsp/server/config/ilp/StreamConfig.java
@@ -1,5 +1,6 @@
 package org.interledger.spsp.server.config.ilp;
 
+import org.interledger.codecs.stream.StreamCodecContextFactory;
 import org.interledger.connector.ccp.codecs.CcpCodecContextFactory;
 import org.interledger.encoding.asn.framework.CodecContext;
 import org.interledger.spsp.stream.ConfigurableSpspStreamConnectionGenerator;
@@ -22,7 +23,7 @@ public class StreamConfig {
   @Bean
   @Qualifier(STREAM)
   public CodecContext streamCodecContext() {
-    return CcpCodecContextFactory.oer();
+    return StreamCodecContextFactory.oer();
   }
 
   @Bean

--- a/src/main/java/org/interledger/spsp/server/config/ilp/StreamConfig.java
+++ b/src/main/java/org/interledger/spsp/server/config/ilp/StreamConfig.java
@@ -1,7 +1,6 @@
 package org.interledger.spsp.server.config.ilp;
 
 import org.interledger.codecs.stream.StreamCodecContextFactory;
-import org.interledger.connector.ccp.codecs.CcpCodecContextFactory;
 import org.interledger.encoding.asn.framework.CodecContext;
 import org.interledger.spsp.stream.ConfigurableSpspStreamConnectionGenerator;
 import org.interledger.stream.crypto.JavaxStreamEncryptionService;


### PR DESCRIPTION
change ConfigurableSpspStreamConnectionGenerator so that the sharedSecret is always derived from the generated local address segment